### PR TITLE
Use any libicu version

### DIFF
--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -136,9 +136,9 @@ LinuxBuild {
 
     !contains(DEFINES, __rasp_pi2__) {
         QT_LIB_LIST += \
-            libicudata.so.56 \
-            libicui18n.so.56 \
-            libicuuc.so.56
+            libicudata.so \
+            libicui18n.so \
+            libicuuc.so
     }
 
     for(QT_LIB, QT_LIB_LIST) {


### PR DESCRIPTION
---
Name: Run with any version of libicu.
---

**Describe the bug**
Application will not link to versions of libicu other then version 56

**To Reproduce**
Steps to reproduce the behavior:
1. Remove icu version 56
2. Install another version of icu
3. Build ok
4. Run time fail... missing libicudata.so.56

**Expected behavior**
 Should run with my system icu lib.